### PR TITLE
Made 98-purge-users more advanced

### DIFF
--- a/98-purge-users.sh
+++ b/98-purge-users.sh
@@ -21,7 +21,7 @@ do
 done
 
 echo "We will now delete leftover TF2 folders.
-read -p "Stop here if you are using syslink for catbot-libraries
+read -p "Stop here if you are using syslink for catbot-libraries"
 for p in $(ls -1 /home | grep catbot-)
 do
 	echo "Removing leftover folder $p"

--- a/98-purge-users.sh
+++ b/98-purge-users.sh
@@ -20,6 +20,8 @@ do
 		done
 done
 
+echo "We will now delete leftover TF2 folders.
+read -p "Stop here if you are using syslink for catbot-libraries
 for p in $(ls -1 /home | grep catbot-)
 do
 	echo "Removing leftover folder $p"

--- a/98-purge-users.sh
+++ b/98-purge-users.sh
@@ -4,11 +4,24 @@
 #	Will delete all catbot- users and their home directories
 #
 
-read -p "Press ENTER to continue"
-
-for i in {1..12}
+if [ $EUID == 0 ]; then
+	echo "This script must not be run as root"
+	exit
+fi
+echo "Doing this will delete all catbot users and folders."
+read -p "Are you sure?"
+for n in $(ls -1 /home | grep cat | wc -l)
 do
-	echo "Deleting user catbot-$i"
-	sudo userdel -r catbot-$i
-	sudo groupdel catbot-$i
+	for u in $(seq 1 $n)
+	do
+		echo "Deleting user catbot-$u"
+		sudo userdel -r catbot-$u
+		sudo groupdel catbot-$u
+		done
+done
+
+for p in $(ls -1 /home | grep catbot-)
+do
+	echo "Removing leftover folder $p"
+	sudo rm -rf /home/$p
 done


### PR DESCRIPTION
No longer deletes hard-coded users (1..12), instead detects how many users start with catbot- and deletes them via number of catbot-* users. I.e., if there are 7 catbot-* users, we'll delete catbot-(1..7)

We'll also delete leftover catbot-* folders, specifically in case user is using custom catbot-libraries folder.

Will add a quick pause before deleting the leftover folders in case user doesn't want to re-download TF2. Although, all of this shouldn't be a problem if they're following the scripts 100%.