### PR TITLE
Proposing alternative 93-steam-symlink

### DIFF
--- a/old/93-1-steam-symlink-test.sh
+++ b/old/93-1-steam-symlink-test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "$#" == 1 ]; then
+	max=$1
+fi
+for i in $(seq 1 "$max")
+do
+sudo mkdir -p /home/"$(cat kisak)"-"$i"
+sudo chown "$(cat kisak)"-"$i":"$(cat kisak)"s /home/"$(cat kisak)"-"$i"
+
+sudo -H -u "$(cat kisak)"-"$i" bash -c "mkdir -p /home/$(cat kisak)-$i/.steam/steam"
+sudo -H -u "$(cat kisak)"-"$i" bash -c "ln -s \"/opt/steamapps\" \"/home/$(cat kisak)-$i/.steam/steam/\""
+sudo -H -u "$(cat kisak)"-"$i" bash -c "touch ~/.steam/steam_install_agreement.txt"
+done


### PR DESCRIPTION
For use after user uses 03-create-users.sh in the future after already setting up everything else.

May or may not be a better alternative to 93-steam-symlink.sh, but this worked for me.