### PR TITLE
Add file name stuff

### DIFF
--- a/install-catbots
+++ b/install-catbots
@@ -13,22 +13,22 @@ if ! [ -e "/opt/cathook/" ]; then
 fi
 
 if [ ! -x "$(command -v touch)" ]; then
-    echo "Touch doesn't exist. Please install it."
+    echo "Touch doesn't exist. Please install it. (touch)"
     exit
 fi
 
 if [ ! -x "$(command -v npm)" ]; then
-    echo "NPM doesn't exist. Please install it."
+    echo "NPM doesn't exist. Please install it. (npm)"
     exit
 fi
 
 if [ ! -x "$(command -v firejail)" ]; then
-    echo "Firejail doesn't exist. Please install it."
+    echo "Firejail doesn't exist. Please install it. (firejail)"
     exit
 fi
 
 if [ ! -x "$(command -v route)" ] && [ ! -x /sbin/route ]; then
-    echo "Route doesn't exist. Please install it (net-tools on archlinux/manjaro)."
+    echo "Route doesn't exist. Please install it. (net-tools)"
     exit
 fi
 


### PR DESCRIPTION
`sudo apt install net-tools` works for ubuntu, so it's not "only" archlinux/manjaro. Kinda confused me-

In fact, this whole installation thing confused a few of my friends who took a few tries to install stuff. So I've added the names of the packages so even the most basic morons can install it without somebody else going "No no, it's firejail - as in, without a capital letter.

Need to add the other packages for the other required stuff

Feel free to deny if you don't feel this is necessary, I just feel that it's necessary after the third friend asked how to install route